### PR TITLE
Add explorer API and Toccata metrics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+target
+docker/.work
+**/.DS_Store
+**/*.log
+**/*.tmp

--- a/README.md
+++ b/README.md
@@ -105,9 +105,40 @@ cargo run -- -s ws://<kaspad_host>:17110 -d postgres://postgres:postgres@<postgr
 ```
 
 ## API
-There is a simple api available at http://localhost:8500/api (by default), it currently provides the following endpoints:
-- health
-- metrics
+There is a REST API available at http://localhost:8500/api (by default).
+An operator dashboard is available at http://localhost:8500/admin.
+
+Operational endpoints:
+- `GET /api/health`
+- `GET /api/metrics`
+- `GET /api/status`
+
+`/api/metrics` includes a `toccata` section for post-Toccata monitoring. The
+current schema exposes transaction/block version and user-lane counters from the
+existing database columns, and marks not-yet-indexed fields such as
+`storageMass`, `computeBudget`, covenant bindings, gas, ZK proofs, and lane
+proof RPCs as unsupported until the underlying schema stores them.
+
+Explorer/indexer endpoints:
+- `GET /api/blocks/recent?limit=50`
+- `GET /api/blocks/{hash}`
+- `GET /api/transactions/{transaction_id}`
+- `GET /api/addresses/{address}/transactions?limit=50`
+- `GET /api/addresses/{address}/balance`
+- `GET /api/addresses/{address}/utxos?limit=100`
+- `GET /api/search?q={hash-or-address}`
+
+The address balance and UTXO endpoints are read-only projections over the
+indexed transaction outputs and inputs. For high-volume explorer deployments,
+keep `transactions`, `transactions.inputs`, `transactions.outputs`, and
+`addresses_transactions` enabled.
+
+Example:
+```shell
+curl "http://localhost:8500/api/status"
+curl "http://localhost:8500/api/blocks/recent?limit=10"
+curl "http://localhost:8500/api/addresses/kaspa:q.../balance"
+```
 
 ## Configuration examples
 

--- a/database/migrations/schema/up.sql
+++ b/database/migrations/schema/up.sql
@@ -4,7 +4,7 @@ CREATE TABLE vars
     value TEXT NOT NULL
 );
 INSERT INTO vars (key, value)
-VALUES ('schema_version', '23');
+VALUES ('schema_version', '24');
 
 
 CREATE TABLE blocks
@@ -117,7 +117,8 @@ CREATE INDEX ON scripts_transactions (block_time DESC);
 CREATE TABLE toccata_metrics
 (
     key   TEXT PRIMARY KEY,
-    value BIGINT NOT NULL DEFAULT 0
+    value BIGINT NOT NULL DEFAULT 0,
+    updated_at BIGINT
 );
 
 INSERT INTO toccata_metrics (key, value)
@@ -150,15 +151,18 @@ CREATE TABLE toccata_lanes
 
 CREATE OR REPLACE FUNCTION bump_toccata_metric(metric_key TEXT, delta BIGINT)
 RETURNS VOID AS $$
+DECLARE
+    now_ms BIGINT := (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
 BEGIN
     IF delta = 0 THEN
         RETURN;
     END IF;
 
-    INSERT INTO toccata_metrics (key, value)
-    VALUES (metric_key, delta)
+    INSERT INTO toccata_metrics (key, value, updated_at)
+    VALUES (metric_key, delta, now_ms)
     ON CONFLICT (key) DO UPDATE
-    SET value = toccata_metrics.value + EXCLUDED.value;
+    SET value = toccata_metrics.value + EXCLUDED.value,
+        updated_at = EXCLUDED.updated_at;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/database/migrations/schema/v22_to_v23.sql
+++ b/database/migrations/schema/v22_to_v23.sql
@@ -1,118 +1,6 @@
-CREATE TABLE vars
-(
-    key   VARCHAR(255) PRIMARY KEY,
-    value TEXT NOT NULL
-);
-INSERT INTO vars (key, value)
-VALUES ('schema_version', '23');
-
-
-CREATE TABLE blocks
-(
-    hash                    BYTEA PRIMARY KEY,
-    accepted_id_merkle_root BYTEA,
-    merge_set_blues_hashes  BYTEA[],
-    merge_set_reds_hashes   BYTEA[],
-    selected_parent_hash    BYTEA,
-    bits                    BIGINT,
-    blue_score              BIGINT,
-    blue_work               BYTEA,
-    daa_score               BIGINT,
-    hash_merkle_root        BYTEA,
-    nonce                   BYTEA,
-    pruning_point           BYTEA,
-    "timestamp"             BIGINT,
-    utxo_commitment         BYTEA,
-    version                 SMALLINT
-);
-CREATE INDEX ON blocks (blue_score);
-
-
-CREATE TABLE block_parent
-(
-    block_hash  BYTEA,
-    parent_hash BYTEA,
-    PRIMARY KEY (block_hash, parent_hash)
-);
-CREATE INDEX ON block_parent (parent_hash);
-
-
-CREATE TYPE transactions_inputs AS
-(
-    index                    SMALLINT,
-    previous_outpoint_hash   BYTEA,
-    previous_outpoint_index  SMALLINT,
-    signature_script         BYTEA,
-    sig_op_count             SMALLINT,
-    previous_outpoint_script BYTEA,
-    previous_outpoint_amount BIGINT,
-    compute_budget           SMALLINT,
-    covenant_id              BYTEA
-);
-
-
-CREATE TYPE transactions_outputs AS
-(
-    index                      SMALLINT,
-    amount                     BIGINT,
-    script_public_key          BYTEA,
-    script_public_key_address  TEXT,
-    covenant_authorizing_input SMALLINT,
-    covenant_id                BYTEA
-);
-
-
-CREATE TABLE transactions
-(
-    transaction_id BYTEA PRIMARY KEY,
-    subnetwork_id  BYTEA,
-    hash           BYTEA,
-    mass           INTEGER,
-    payload        BYTEA,
-    block_time     BIGINT,
-    version        SMALLINT,
-    inputs         transactions_inputs[],
-    outputs        transactions_outputs[]
-);
-CREATE INDEX ON transactions (block_time DESC);
-
-
-CREATE TABLE transactions_acceptances
-(
-    transaction_id BYTEA UNIQUE,
-    block_hash     BYTEA
-);
-CREATE INDEX ON transactions_acceptances (block_hash);
-
-
-CREATE TABLE blocks_transactions
-(
-    block_hash     BYTEA,
-    transaction_id BYTEA,
-    PRIMARY KEY (block_hash, transaction_id)
-);
-CREATE INDEX ON blocks_transactions (transaction_id);
-
-
-CREATE TABLE addresses_transactions
-(
-    address        TEXT,
-    transaction_id BYTEA,
-    block_time     BIGINT,
-    PRIMARY KEY (address, block_time, transaction_id)
-);
-CREATE INDEX ON addresses_transactions (block_time DESC);
-
-
-CREATE TABLE scripts_transactions
-(
-    script_public_key BYTEA,
-    transaction_id    BYTEA,
-    block_time        BIGINT,
-    PRIMARY KEY (script_public_key, block_time, transaction_id)
-);
-CREATE INDEX ON scripts_transactions (block_time DESC);
-
+--------------------------------------------------------------
+-- v23: Toccata metrics rollups
+--------------------------------------------------------------
 
 CREATE TABLE toccata_metrics
 (
@@ -262,3 +150,6 @@ CREATE TRIGGER transactions_toccata_metrics_insert
 AFTER INSERT ON transactions
 FOR EACH ROW
 EXECUTE FUNCTION update_toccata_transaction_metrics();
+
+-- Update schema_version
+UPDATE vars SET value = '23' WHERE key = 'schema_version';

--- a/database/migrations/schema/v23_to_v24.sql
+++ b/database/migrations/schema/v23_to_v24.sql
@@ -1,0 +1,29 @@
+--------------------------------------------------------------
+-- v24: Toccata rollup freshness
+--------------------------------------------------------------
+
+ALTER TABLE toccata_metrics ADD COLUMN updated_at BIGINT;
+
+UPDATE toccata_metrics
+SET updated_at = (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT
+WHERE value > 0;
+
+CREATE OR REPLACE FUNCTION bump_toccata_metric(metric_key TEXT, delta BIGINT)
+RETURNS VOID AS $$
+DECLARE
+    now_ms BIGINT := (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT;
+BEGIN
+    IF delta = 0 THEN
+        RETURN;
+    END IF;
+
+    INSERT INTO toccata_metrics (key, value, updated_at)
+    VALUES (metric_key, delta, now_ms)
+    ON CONFLICT (key) DO UPDATE
+    SET value = toccata_metrics.value + EXCLUDED.value,
+        updated_at = EXCLUDED.updated_at;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update schema_version
+UPDATE vars SET value = '24' WHERE key = 'schema_version';

--- a/database/src/client.rs
+++ b/database/src/client.rs
@@ -9,6 +9,9 @@ use crate::models::address_transaction::AddressTransaction;
 use crate::models::block::Block;
 use crate::models::block_parent::BlockParent;
 use crate::models::block_transaction::BlockTransaction;
+use crate::models::query::api::{
+    ApiAddressBalance, ApiAddressTransaction, ApiAddressUtxo, ApiBlock, ApiSearchResult, ApiToccataMetrics, ApiTransaction,
+};
 use crate::models::query::database_details::DatabaseDetails;
 use crate::models::query::table_details::TableDetails;
 use crate::models::script_transaction::ScriptTransaction;
@@ -23,7 +26,7 @@ pub struct KaspaDbClient {
 }
 
 impl KaspaDbClient {
-    const SCHEMA_VERSION: u8 = 22;
+    pub const SCHEMA_VERSION: u8 = 22;
 
     pub async fn new(url: &str, pool_size: u32) -> Result<KaspaDbClient, Error> {
         let url_cleaned = Regex::new(r"(postgres://postgres:)[^@]+(@)").expect("Failed to parse url").replace(url, "$1$2");
@@ -223,6 +226,38 @@ impl KaspaDbClient {
 
     pub async fn select_is_chain_block(&self, block_hash: &Hash) -> Result<bool, Error> {
         query::select::select_is_chain_block(block_hash, &self.pool).await
+    }
+
+    pub async fn select_recent_blocks(&self, limit: i64) -> Result<Vec<ApiBlock>, Error> {
+        query::select::select_recent_blocks(limit, &self.pool).await
+    }
+
+    pub async fn select_block(&self, hash: &Hash) -> Result<Option<ApiBlock>, Error> {
+        query::select::select_block(hash, &self.pool).await
+    }
+
+    pub async fn select_transaction(&self, transaction_id: &Hash) -> Result<Option<ApiTransaction>, Error> {
+        query::select::select_transaction(transaction_id, &self.pool).await
+    }
+
+    pub async fn select_address_transactions(&self, address: &str, limit: i64) -> Result<Vec<ApiAddressTransaction>, Error> {
+        query::select::select_address_transactions(address, limit, &self.pool).await
+    }
+
+    pub async fn select_address_balance(&self, address: &str) -> Result<ApiAddressBalance, Error> {
+        query::select::select_address_balance(address, &self.pool).await
+    }
+
+    pub async fn select_address_utxos(&self, address: &str, limit: i64) -> Result<Vec<ApiAddressUtxo>, Error> {
+        query::select::select_address_utxos(address, limit, &self.pool).await
+    }
+
+    pub async fn select_search(&self, query: &str, limit: i64) -> Result<Vec<ApiSearchResult>, Error> {
+        query::select::select_search(query, limit, &self.pool).await
+    }
+
+    pub async fn select_toccata_metrics(&self) -> Result<ApiToccataMetrics, Error> {
+        query::select::select_toccata_metrics(&self.pool).await
     }
 
     pub async fn insert_blocks(&self, blocks: &[Block]) -> Result<u64, Error> {

--- a/database/src/client.rs
+++ b/database/src/client.rs
@@ -26,7 +26,7 @@ pub struct KaspaDbClient {
 }
 
 impl KaspaDbClient {
-    pub const SCHEMA_VERSION: u8 = 22;
+    pub const SCHEMA_VERSION: u8 = 23;
 
     pub async fn new(url: &str, pool_size: u32) -> Result<KaspaDbClient, Error> {
         let url_cleaned = Regex::new(r"(postgres://postgres:)[^@]+(@)").expect("Failed to parse url").replace(url, "$1$2");
@@ -174,6 +174,17 @@ impl KaspaDbClient {
                     }
                     if version == 21 {
                         let ddl = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/schema/v21_to_v22.sql"));
+                        if upgrade_db {
+                            warn!("\n{ddl}\nUpgrading schema from v{version} to v{}. ^", version + 1);
+                            query::misc::execute_ddl(ddl, &self.pool).await?;
+                            info!("\x1b[32mSchema upgrade completed successfully\x1b[0m");
+                            version += 1;
+                        } else {
+                            panic!("\n{ddl}\nFound outdated schema v{version}. Set flag '-u' to upgrade, or apply manually ^")
+                        }
+                    }
+                    if version == 22 {
+                        let ddl = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/schema/v22_to_v23.sql"));
                         if upgrade_db {
                             warn!("\n{ddl}\nUpgrading schema from v{version} to v{}. ^", version + 1);
                             query::misc::execute_ddl(ddl, &self.pool).await?;

--- a/database/src/client.rs
+++ b/database/src/client.rs
@@ -26,7 +26,7 @@ pub struct KaspaDbClient {
 }
 
 impl KaspaDbClient {
-    pub const SCHEMA_VERSION: u8 = 23;
+    pub const SCHEMA_VERSION: u8 = 24;
 
     pub async fn new(url: &str, pool_size: u32) -> Result<KaspaDbClient, Error> {
         let url_cleaned = Regex::new(r"(postgres://postgres:)[^@]+(@)").expect("Failed to parse url").replace(url, "$1$2");
@@ -185,6 +185,17 @@ impl KaspaDbClient {
                     }
                     if version == 22 {
                         let ddl = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/schema/v22_to_v23.sql"));
+                        if upgrade_db {
+                            warn!("\n{ddl}\nUpgrading schema from v{version} to v{}. ^", version + 1);
+                            query::misc::execute_ddl(ddl, &self.pool).await?;
+                            info!("\x1b[32mSchema upgrade completed successfully\x1b[0m");
+                            version += 1;
+                        } else {
+                            panic!("\n{ddl}\nFound outdated schema v{version}. Set flag '-u' to upgrade, or apply manually ^")
+                        }
+                    }
+                    if version == 23 {
+                        let ddl = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/migrations/schema/v23_to_v24.sql"));
                         if upgrade_db {
                             warn!("\n{ddl}\nUpgrading schema from v{version} to v{}. ^", version + 1);
                             query::misc::execute_ddl(ddl, &self.pool).await?;

--- a/database/src/models/query/api.rs
+++ b/database/src/models/query/api.rs
@@ -1,0 +1,74 @@
+use crate::models::types::hash::Hash;
+
+pub struct ApiBlock {
+    pub hash: Hash,
+    pub selected_parent_hash: Option<Hash>,
+    pub blue_score: Option<i64>,
+    pub daa_score: Option<i64>,
+    pub timestamp: Option<i64>,
+    pub version: Option<i16>,
+    pub transaction_count: i64,
+    pub is_chain_block: bool,
+}
+
+pub struct ApiTransaction {
+    pub transaction_id: Hash,
+    pub hash: Option<Hash>,
+    pub block_time: Option<i64>,
+    pub version: Option<i16>,
+    pub mass: Option<i32>,
+    pub block_hashes: Vec<Hash>,
+    pub accepted_block_hash: Option<Hash>,
+}
+
+pub struct ApiAddressTransaction {
+    pub address: String,
+    pub transaction_id: Hash,
+    pub block_time: i64,
+}
+
+pub struct ApiAddressBalance {
+    pub address: String,
+    pub balance_sompi: i64,
+    pub utxo_count: i64,
+}
+
+pub struct ApiAddressUtxo {
+    pub transaction_id: Hash,
+    pub output_index: i16,
+    pub amount_sompi: i64,
+    pub block_time: Option<i64>,
+}
+
+pub struct ApiSearchResult {
+    pub kind: String,
+    pub value: String,
+}
+
+pub struct ApiToccataMetrics {
+    pub tx_v1_count: i64,
+    pub block_v2_count: i64,
+    pub covenant_tx_count: i64,
+    pub covenant_input_count: i64,
+    pub covenant_output_count: i64,
+    pub covenant_id_count: i64,
+    pub user_lane_tx_count: i64,
+    pub active_user_lanes: i64,
+    pub seq_commit_block_count: i64,
+    pub top_covenants: Vec<ApiToccataCovenantMetrics>,
+    pub top_lanes: Vec<ApiToccataLaneMetrics>,
+}
+
+pub struct ApiToccataCovenantMetrics {
+    pub covenant_id: String,
+    pub tx_count: i64,
+    pub input_count: i64,
+    pub output_count: i64,
+    pub latest_tx_id: Option<Hash>,
+}
+
+pub struct ApiToccataLaneMetrics {
+    pub lane_key: String,
+    pub tx_count: i64,
+    pub latest_tx_id: Option<Hash>,
+}

--- a/database/src/models/query/api.rs
+++ b/database/src/models/query/api.rs
@@ -46,6 +46,7 @@ pub struct ApiSearchResult {
 }
 
 pub struct ApiToccataMetrics {
+    pub rollup_updated_at: Option<i64>,
     pub tx_v1_count: i64,
     pub block_v2_count: i64,
     pub covenant_tx_count: i64,

--- a/database/src/models/query/mod.rs
+++ b/database/src/models/query/mod.rs
@@ -1,2 +1,3 @@
+pub mod api;
 pub mod database_details;
 pub mod table_details;

--- a/database/src/query/select.rs
+++ b/database/src/query/select.rs
@@ -291,70 +291,16 @@ pub async fn select_search(query: &str, limit: i64, pool: &Pool<Postgres>) -> Re
 pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataMetrics, Error> {
     let aggregate = sqlx::query(
         "
-        WITH recent_transactions AS (
-            SELECT *
-            FROM transactions
-            WHERE block_time >= (
-                SELECT COALESCE(MAX(block_time) - 3600000, 0)
-                FROM transactions
-            )
-        )
         SELECT
-            (SELECT COUNT(*) FROM recent_transactions WHERE version >= 1)::BIGINT AS tx_v1_count,
-            0::BIGINT AS block_v2_count,
-            (
-                SELECT COUNT(DISTINCT transaction_id)
-                FROM (
-                    SELECT t.transaction_id
-                    FROM recent_transactions t
-                    CROSS JOIN LATERAL unnest(t.inputs) AS i
-                    WHERE (i).covenant_id IS NOT NULL
-                    UNION
-                    SELECT t.transaction_id
-                    FROM recent_transactions t
-                    CROSS JOIN LATERAL unnest(t.outputs) AS o
-                    WHERE (o).covenant_id IS NOT NULL
-                ) covenant_txs
-            )::BIGINT AS covenant_tx_count,
-            (
-                SELECT COUNT(*)
-                FROM recent_transactions t
-                CROSS JOIN LATERAL unnest(t.inputs) AS i
-                WHERE (i).covenant_id IS NOT NULL
-            )::BIGINT AS covenant_input_count,
-            (
-                SELECT COUNT(*)
-                FROM recent_transactions t
-                CROSS JOIN LATERAL unnest(t.outputs) AS o
-                WHERE (o).covenant_id IS NOT NULL
-            )::BIGINT AS covenant_output_count,
-            (
-                SELECT COUNT(DISTINCT covenant_id)
-                FROM (
-                    SELECT (i).covenant_id
-                    FROM recent_transactions t
-                    CROSS JOIN LATERAL unnest(t.inputs) AS i
-                    WHERE (i).covenant_id IS NOT NULL
-                    UNION
-                    SELECT (o).covenant_id
-                    FROM recent_transactions t
-                    CROSS JOIN LATERAL unnest(t.outputs) AS o
-                    WHERE (o).covenant_id IS NOT NULL
-                ) covenant_ids
-            )::BIGINT AS covenant_id_count,
-            (
-                SELECT COUNT(*)
-                FROM recent_transactions
-                WHERE subnetwork_id IS NOT NULL
-                  AND octet_length(subnetwork_id) BETWEEN 1 AND 4
-            )::BIGINT AS user_lane_tx_count,
-            (
-                SELECT COUNT(DISTINCT subnetwork_id)
-                FROM recent_transactions
-                WHERE subnetwork_id IS NOT NULL
-                  AND octet_length(subnetwork_id) BETWEEN 1 AND 4
-            )::BIGINT AS active_user_lanes,
-            0::BIGINT AS seq_commit_block_count
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'tx_v1_count'), 0)::BIGINT AS tx_v1_count,
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'block_v2_count'), 0)::BIGINT AS block_v2_count,
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'covenant_tx_count'), 0)::BIGINT AS covenant_tx_count,
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'covenant_input_count'), 0)::BIGINT AS covenant_input_count,
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'covenant_output_count'), 0)::BIGINT AS covenant_output_count,
+            (SELECT COUNT(*) FROM toccata_covenants)::BIGINT AS covenant_id_count,
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'user_lane_tx_count'), 0)::BIGINT AS user_lane_tx_count,
+            (SELECT COUNT(*) FROM toccata_lanes)::BIGINT AS active_user_lanes,
+            COALESCE((SELECT value FROM toccata_metrics WHERE key = 'seq_commit_block_count'), 0)::BIGINT AS seq_commit_block_count
         ",
     )
     .fetch_one(pool)
@@ -362,43 +308,13 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
 
     let top_covenants = sqlx::query(
         "
-        WITH covenant_events AS (
-            WITH recent_transactions AS (
-                SELECT *
-                FROM transactions
-                WHERE block_time >= (
-                    SELECT COALESCE(MAX(block_time) - 3600000, 0)
-                    FROM transactions
-                )
-            )
-            SELECT
-                t.transaction_id,
-                t.block_time,
-                (i).covenant_id,
-                1::BIGINT AS input_count,
-                0::BIGINT AS output_count
-            FROM recent_transactions t
-            CROSS JOIN LATERAL unnest(t.inputs) AS i
-            WHERE (i).covenant_id IS NOT NULL
-            UNION ALL
-            SELECT
-                t.transaction_id,
-                t.block_time,
-                (o).covenant_id,
-                0::BIGINT AS input_count,
-                1::BIGINT AS output_count
-            FROM recent_transactions t
-            CROSS JOIN LATERAL unnest(t.outputs) AS o
-            WHERE (o).covenant_id IS NOT NULL
-        )
         SELECT
             encode(covenant_id, 'hex') AS covenant_id,
-            COUNT(DISTINCT transaction_id)::BIGINT AS tx_count,
-            SUM(input_count)::BIGINT AS input_count,
-            SUM(output_count)::BIGINT AS output_count,
-            (array_agg(transaction_id ORDER BY block_time DESC NULLS LAST))[1] AS latest_tx_id
-        FROM covenant_events
-        GROUP BY covenant_id
+            tx_count,
+            input_count,
+            output_count,
+            latest_tx_id
+        FROM toccata_covenants
         ORDER BY tx_count DESC, output_count DESC
         LIMIT 20
         ",
@@ -420,17 +336,10 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
     let top_lanes = sqlx::query(
         "
         SELECT
-            encode(subnetwork_id, 'hex') AS lane_key,
-            COUNT(*)::BIGINT AS tx_count,
-            (array_agg(transaction_id ORDER BY block_time DESC NULLS LAST))[1] AS latest_tx_id
-        FROM transactions
-        WHERE block_time >= (
-            SELECT COALESCE(MAX(block_time) - 3600000, 0)
-            FROM transactions
-        )
-          AND subnetwork_id IS NOT NULL
-          AND octet_length(subnetwork_id) BETWEEN 1 AND 4
-        GROUP BY subnetwork_id
+            encode(lane_key, 'hex') AS lane_key,
+            tx_count,
+            latest_tx_id
+        FROM toccata_lanes
         ORDER BY tx_count DESC
         LIMIT 20
         ",

--- a/database/src/query/select.rs
+++ b/database/src/query/select.rs
@@ -292,6 +292,7 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
     let aggregate = sqlx::query(
         "
         SELECT
+            (SELECT MAX(updated_at) FROM toccata_metrics)::BIGINT AS rollup_updated_at,
             COALESCE((SELECT value FROM toccata_metrics WHERE key = 'tx_v1_count'), 0)::BIGINT AS tx_v1_count,
             COALESCE((SELECT value FROM toccata_metrics WHERE key = 'block_v2_count'), 0)::BIGINT AS block_v2_count,
             COALESCE((SELECT value FROM toccata_metrics WHERE key = 'covenant_tx_count'), 0)::BIGINT AS covenant_tx_count,
@@ -357,6 +358,7 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
     .collect::<Result<Vec<_>, Error>>()?;
 
     Ok(ApiToccataMetrics {
+        rollup_updated_at: aggregate.try_get("rollup_updated_at")?,
         tx_v1_count: aggregate.try_get("tx_v1_count")?,
         block_v2_count: aggregate.try_get("block_v2_count")?,
         covenant_tx_count: aggregate.try_get("covenant_tx_count")?,

--- a/database/src/query/select.rs
+++ b/database/src/query/select.rs
@@ -291,32 +291,40 @@ pub async fn select_search(query: &str, limit: i64, pool: &Pool<Postgres>) -> Re
 pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataMetrics, Error> {
     let aggregate = sqlx::query(
         "
+        WITH recent_transactions AS (
+            SELECT *
+            FROM transactions
+            WHERE block_time >= (
+                SELECT COALESCE(MAX(block_time) - 3600000, 0)
+                FROM transactions
+            )
+        )
         SELECT
-            (SELECT COUNT(*) FROM transactions WHERE version >= 1)::BIGINT AS tx_v1_count,
-            (SELECT COUNT(*) FROM blocks WHERE version >= 2)::BIGINT AS block_v2_count,
+            (SELECT COUNT(*) FROM recent_transactions WHERE version >= 1)::BIGINT AS tx_v1_count,
+            0::BIGINT AS block_v2_count,
             (
                 SELECT COUNT(DISTINCT transaction_id)
                 FROM (
                     SELECT t.transaction_id
-                    FROM transactions t
+                    FROM recent_transactions t
                     CROSS JOIN LATERAL unnest(t.inputs) AS i
                     WHERE (i).covenant_id IS NOT NULL
                     UNION
                     SELECT t.transaction_id
-                    FROM transactions t
+                    FROM recent_transactions t
                     CROSS JOIN LATERAL unnest(t.outputs) AS o
                     WHERE (o).covenant_id IS NOT NULL
                 ) covenant_txs
             )::BIGINT AS covenant_tx_count,
             (
                 SELECT COUNT(*)
-                FROM transactions t
+                FROM recent_transactions t
                 CROSS JOIN LATERAL unnest(t.inputs) AS i
                 WHERE (i).covenant_id IS NOT NULL
             )::BIGINT AS covenant_input_count,
             (
                 SELECT COUNT(*)
-                FROM transactions t
+                FROM recent_transactions t
                 CROSS JOIN LATERAL unnest(t.outputs) AS o
                 WHERE (o).covenant_id IS NOT NULL
             )::BIGINT AS covenant_output_count,
@@ -324,34 +332,29 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
                 SELECT COUNT(DISTINCT covenant_id)
                 FROM (
                     SELECT (i).covenant_id
-                    FROM transactions t
+                    FROM recent_transactions t
                     CROSS JOIN LATERAL unnest(t.inputs) AS i
                     WHERE (i).covenant_id IS NOT NULL
                     UNION
                     SELECT (o).covenant_id
-                    FROM transactions t
+                    FROM recent_transactions t
                     CROSS JOIN LATERAL unnest(t.outputs) AS o
                     WHERE (o).covenant_id IS NOT NULL
                 ) covenant_ids
             )::BIGINT AS covenant_id_count,
             (
                 SELECT COUNT(*)
-                FROM transactions
+                FROM recent_transactions
                 WHERE subnetwork_id IS NOT NULL
                   AND octet_length(subnetwork_id) BETWEEN 1 AND 4
             )::BIGINT AS user_lane_tx_count,
             (
                 SELECT COUNT(DISTINCT subnetwork_id)
-                FROM transactions
+                FROM recent_transactions
                 WHERE subnetwork_id IS NOT NULL
                   AND octet_length(subnetwork_id) BETWEEN 1 AND 4
             )::BIGINT AS active_user_lanes,
-            (
-                SELECT COUNT(*)
-                FROM blocks
-                WHERE version >= 2
-                  AND accepted_id_merkle_root IS NOT NULL
-            )::BIGINT AS seq_commit_block_count
+            0::BIGINT AS seq_commit_block_count
         ",
     )
     .fetch_one(pool)
@@ -360,13 +363,21 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
     let top_covenants = sqlx::query(
         "
         WITH covenant_events AS (
+            WITH recent_transactions AS (
+                SELECT *
+                FROM transactions
+                WHERE block_time >= (
+                    SELECT COALESCE(MAX(block_time) - 3600000, 0)
+                    FROM transactions
+                )
+            )
             SELECT
                 t.transaction_id,
                 t.block_time,
                 (i).covenant_id,
                 1::BIGINT AS input_count,
                 0::BIGINT AS output_count
-            FROM transactions t
+            FROM recent_transactions t
             CROSS JOIN LATERAL unnest(t.inputs) AS i
             WHERE (i).covenant_id IS NOT NULL
             UNION ALL
@@ -376,7 +387,7 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
                 (o).covenant_id,
                 0::BIGINT AS input_count,
                 1::BIGINT AS output_count
-            FROM transactions t
+            FROM recent_transactions t
             CROSS JOIN LATERAL unnest(t.outputs) AS o
             WHERE (o).covenant_id IS NOT NULL
         )
@@ -413,7 +424,11 @@ pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataM
             COUNT(*)::BIGINT AS tx_count,
             (array_agg(transaction_id ORDER BY block_time DESC NULLS LAST))[1] AS latest_tx_id
         FROM transactions
-        WHERE subnetwork_id IS NOT NULL
+        WHERE block_time >= (
+            SELECT COALESCE(MAX(block_time) - 3600000, 0)
+            FROM transactions
+        )
+          AND subnetwork_id IS NOT NULL
           AND octet_length(subnetwork_id) BETWEEN 1 AND 4
         GROUP BY subnetwork_id
         ORDER BY tx_count DESC

--- a/database/src/query/select.rs
+++ b/database/src/query/select.rs
@@ -1,3 +1,7 @@
+use crate::models::query::api::{
+    ApiAddressBalance, ApiAddressTransaction, ApiAddressUtxo, ApiBlock, ApiSearchResult, ApiToccataCovenantMetrics,
+    ApiToccataLaneMetrics, ApiToccataMetrics, ApiTransaction,
+};
 use crate::models::query::database_details::DatabaseDetails;
 use crate::models::query::table_details::TableDetails;
 use crate::models::types::hash::Hash;
@@ -53,4 +57,422 @@ pub async fn select_is_chain_block(block_hash: &Hash, pool: &Pool<Postgres>) -> 
         .fetch_one(pool)
         .await?
         .try_get(0)
+}
+
+pub async fn select_recent_blocks(limit: i64, pool: &Pool<Postgres>) -> Result<Vec<ApiBlock>, Error> {
+    sqlx::query(
+        "
+        SELECT
+            b.hash,
+            b.selected_parent_hash,
+            b.blue_score,
+            b.daa_score,
+            b.timestamp,
+            b.version,
+            COUNT(bt.transaction_id)::BIGINT AS transaction_count,
+            EXISTS(SELECT 1 FROM transactions_acceptances ta WHERE ta.block_hash = b.hash) AS is_chain_block
+        FROM blocks b
+        LEFT JOIN blocks_transactions bt ON bt.block_hash = b.hash
+        GROUP BY b.hash
+        ORDER BY b.blue_score DESC NULLS LAST, b.timestamp DESC NULLS LAST
+        LIMIT $1
+        ",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(row_to_api_block)
+    .collect()
+}
+
+pub async fn select_block(hash: &Hash, pool: &Pool<Postgres>) -> Result<Option<ApiBlock>, Error> {
+    sqlx::query(
+        "
+        SELECT
+            b.hash,
+            b.selected_parent_hash,
+            b.blue_score,
+            b.daa_score,
+            b.timestamp,
+            b.version,
+            COUNT(bt.transaction_id)::BIGINT AS transaction_count,
+            EXISTS(SELECT 1 FROM transactions_acceptances ta WHERE ta.block_hash = b.hash) AS is_chain_block
+        FROM blocks b
+        LEFT JOIN blocks_transactions bt ON bt.block_hash = b.hash
+        WHERE b.hash = $1
+        GROUP BY b.hash
+        ",
+    )
+    .bind(hash)
+    .fetch_optional(pool)
+    .await?
+    .map(row_to_api_block)
+    .transpose()
+}
+
+pub async fn select_transaction(transaction_id: &Hash, pool: &Pool<Postgres>) -> Result<Option<ApiTransaction>, Error> {
+    sqlx::query(
+        "
+        SELECT
+            t.transaction_id,
+            t.hash,
+            t.block_time,
+            t.version,
+            t.mass,
+            COALESCE(array_agg(bt.block_hash) FILTER (WHERE bt.block_hash IS NOT NULL), ARRAY[]::BYTEA[]) AS block_hashes,
+            ta.block_hash AS accepted_block_hash
+        FROM transactions t
+        LEFT JOIN blocks_transactions bt ON bt.transaction_id = t.transaction_id
+        LEFT JOIN transactions_acceptances ta ON ta.transaction_id = t.transaction_id
+        WHERE t.transaction_id = $1
+        GROUP BY t.transaction_id, ta.block_hash
+        ",
+    )
+    .bind(transaction_id)
+    .fetch_optional(pool)
+    .await?
+    .map(row_to_api_transaction)
+    .transpose()
+}
+
+pub async fn select_address_transactions(
+    address: &str,
+    limit: i64,
+    pool: &Pool<Postgres>,
+) -> Result<Vec<ApiAddressTransaction>, Error> {
+    sqlx::query(
+        "
+        SELECT address, transaction_id, block_time
+        FROM addresses_transactions
+        WHERE address = $1
+        ORDER BY block_time DESC
+        LIMIT $2
+        ",
+    )
+    .bind(address)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(ApiAddressTransaction {
+            address: row.try_get("address")?,
+            transaction_id: row.try_get("transaction_id")?,
+            block_time: row.try_get("block_time")?,
+        })
+    })
+    .collect()
+}
+
+pub async fn select_address_utxos(address: &str, limit: i64, pool: &Pool<Postgres>) -> Result<Vec<ApiAddressUtxo>, Error> {
+    sqlx::query(
+        "
+        WITH address_txs AS (
+            SELECT DISTINCT transaction_id
+            FROM addresses_transactions
+            WHERE address = $1
+        ),
+        candidate_outputs AS (
+            SELECT
+                t.transaction_id,
+                (o).index AS output_index,
+                (o).amount AS amount_sompi,
+                t.block_time
+            FROM address_txs at
+            JOIN transactions t ON t.transaction_id = at.transaction_id
+            CROSS JOIN LATERAL unnest(t.outputs) AS o
+            WHERE (o).script_public_key_address = $1
+        )
+        SELECT
+            co.transaction_id,
+            co.output_index,
+            co.amount_sompi,
+            co.block_time
+        FROM candidate_outputs co
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM address_txs at_spend
+            JOIN transactions spending ON spending.transaction_id = at_spend.transaction_id
+            CROSS JOIN LATERAL unnest(spending.inputs) AS i
+            WHERE (i).previous_outpoint_hash = co.transaction_id
+              AND (i).previous_outpoint_index = co.output_index
+        )
+        ORDER BY co.block_time DESC NULLS LAST, co.output_index ASC
+        LIMIT $2
+        ",
+    )
+    .bind(address)
+    .bind(limit)
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(ApiAddressUtxo {
+            transaction_id: row.try_get("transaction_id")?,
+            output_index: row.try_get("output_index")?,
+            amount_sompi: row.try_get("amount_sompi")?,
+            block_time: row.try_get("block_time")?,
+        })
+    })
+    .collect()
+}
+
+pub async fn select_address_balance(address: &str, pool: &Pool<Postgres>) -> Result<ApiAddressBalance, Error> {
+    let row = sqlx::query(
+        "
+        WITH address_txs AS (
+            SELECT DISTINCT transaction_id
+            FROM addresses_transactions
+            WHERE address = $1
+        ),
+        candidate_outputs AS (
+            SELECT
+                t.transaction_id,
+                (o).index AS output_index,
+                (o).amount AS amount_sompi
+            FROM address_txs at
+            JOIN transactions t ON t.transaction_id = at.transaction_id
+            CROSS JOIN LATERAL unnest(t.outputs) AS o
+            WHERE (o).script_public_key_address = $1
+        )
+        SELECT
+            COALESCE(SUM(co.amount_sompi), 0)::BIGINT AS balance_sompi,
+            COUNT(*)::BIGINT AS utxo_count
+        FROM candidate_outputs co
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM address_txs at_spend
+            JOIN transactions spending ON spending.transaction_id = at_spend.transaction_id
+            CROSS JOIN LATERAL unnest(spending.inputs) AS i
+            WHERE (i).previous_outpoint_hash = co.transaction_id
+              AND (i).previous_outpoint_index = co.output_index
+        )
+        ",
+    )
+    .bind(address)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(ApiAddressBalance {
+        address: address.to_string(),
+        balance_sompi: row.try_get("balance_sompi")?,
+        utxo_count: row.try_get("utxo_count")?,
+    })
+}
+
+pub async fn select_search(query: &str, limit: i64, pool: &Pool<Postgres>) -> Result<Vec<ApiSearchResult>, Error> {
+    let mut results = Vec::new();
+
+    if let Ok(hash) = parse_hash(query) {
+        if sqlx::query("SELECT 1 FROM blocks WHERE hash = $1").bind(&hash).fetch_optional(pool).await?.is_some() {
+            results.push(ApiSearchResult { kind: "block".to_string(), value: hash.to_string() });
+        }
+        if sqlx::query("SELECT 1 FROM transactions WHERE transaction_id = $1").bind(&hash).fetch_optional(pool).await?.is_some() {
+            results.push(ApiSearchResult { kind: "transaction".to_string(), value: hash.to_string() });
+        }
+    }
+
+    if query.starts_with("kaspa") {
+        let count: i64 = sqlx::query("SELECT COUNT(*) FROM addresses_transactions WHERE address = $1")
+            .bind(query)
+            .fetch_one(pool)
+            .await?
+            .try_get(0)?;
+        if count > 0 {
+            results.push(ApiSearchResult { kind: "address".to_string(), value: query.to_string() });
+        }
+    }
+
+    results.truncate(limit as usize);
+    Ok(results)
+}
+
+pub async fn select_toccata_metrics(pool: &Pool<Postgres>) -> Result<ApiToccataMetrics, Error> {
+    let aggregate = sqlx::query(
+        "
+        SELECT
+            (SELECT COUNT(*) FROM transactions WHERE version >= 1)::BIGINT AS tx_v1_count,
+            (SELECT COUNT(*) FROM blocks WHERE version >= 2)::BIGINT AS block_v2_count,
+            (
+                SELECT COUNT(DISTINCT transaction_id)
+                FROM (
+                    SELECT t.transaction_id
+                    FROM transactions t
+                    CROSS JOIN LATERAL unnest(t.inputs) AS i
+                    WHERE (i).covenant_id IS NOT NULL
+                    UNION
+                    SELECT t.transaction_id
+                    FROM transactions t
+                    CROSS JOIN LATERAL unnest(t.outputs) AS o
+                    WHERE (o).covenant_id IS NOT NULL
+                ) covenant_txs
+            )::BIGINT AS covenant_tx_count,
+            (
+                SELECT COUNT(*)
+                FROM transactions t
+                CROSS JOIN LATERAL unnest(t.inputs) AS i
+                WHERE (i).covenant_id IS NOT NULL
+            )::BIGINT AS covenant_input_count,
+            (
+                SELECT COUNT(*)
+                FROM transactions t
+                CROSS JOIN LATERAL unnest(t.outputs) AS o
+                WHERE (o).covenant_id IS NOT NULL
+            )::BIGINT AS covenant_output_count,
+            (
+                SELECT COUNT(DISTINCT covenant_id)
+                FROM (
+                    SELECT (i).covenant_id
+                    FROM transactions t
+                    CROSS JOIN LATERAL unnest(t.inputs) AS i
+                    WHERE (i).covenant_id IS NOT NULL
+                    UNION
+                    SELECT (o).covenant_id
+                    FROM transactions t
+                    CROSS JOIN LATERAL unnest(t.outputs) AS o
+                    WHERE (o).covenant_id IS NOT NULL
+                ) covenant_ids
+            )::BIGINT AS covenant_id_count,
+            (
+                SELECT COUNT(*)
+                FROM transactions
+                WHERE subnetwork_id IS NOT NULL
+                  AND octet_length(subnetwork_id) BETWEEN 1 AND 4
+            )::BIGINT AS user_lane_tx_count,
+            (
+                SELECT COUNT(DISTINCT subnetwork_id)
+                FROM transactions
+                WHERE subnetwork_id IS NOT NULL
+                  AND octet_length(subnetwork_id) BETWEEN 1 AND 4
+            )::BIGINT AS active_user_lanes,
+            (
+                SELECT COUNT(*)
+                FROM blocks
+                WHERE version >= 2
+                  AND accepted_id_merkle_root IS NOT NULL
+            )::BIGINT AS seq_commit_block_count
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let top_covenants = sqlx::query(
+        "
+        WITH covenant_events AS (
+            SELECT
+                t.transaction_id,
+                t.block_time,
+                (i).covenant_id,
+                1::BIGINT AS input_count,
+                0::BIGINT AS output_count
+            FROM transactions t
+            CROSS JOIN LATERAL unnest(t.inputs) AS i
+            WHERE (i).covenant_id IS NOT NULL
+            UNION ALL
+            SELECT
+                t.transaction_id,
+                t.block_time,
+                (o).covenant_id,
+                0::BIGINT AS input_count,
+                1::BIGINT AS output_count
+            FROM transactions t
+            CROSS JOIN LATERAL unnest(t.outputs) AS o
+            WHERE (o).covenant_id IS NOT NULL
+        )
+        SELECT
+            encode(covenant_id, 'hex') AS covenant_id,
+            COUNT(DISTINCT transaction_id)::BIGINT AS tx_count,
+            SUM(input_count)::BIGINT AS input_count,
+            SUM(output_count)::BIGINT AS output_count,
+            (array_agg(transaction_id ORDER BY block_time DESC NULLS LAST))[1] AS latest_tx_id
+        FROM covenant_events
+        GROUP BY covenant_id
+        ORDER BY tx_count DESC, output_count DESC
+        LIMIT 20
+        ",
+    )
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(ApiToccataCovenantMetrics {
+            covenant_id: row.try_get("covenant_id")?,
+            tx_count: row.try_get("tx_count")?,
+            input_count: row.try_get("input_count")?,
+            output_count: row.try_get("output_count")?,
+            latest_tx_id: row.try_get("latest_tx_id")?,
+        })
+    })
+    .collect::<Result<Vec<_>, Error>>()?;
+
+    let top_lanes = sqlx::query(
+        "
+        SELECT
+            encode(subnetwork_id, 'hex') AS lane_key,
+            COUNT(*)::BIGINT AS tx_count,
+            (array_agg(transaction_id ORDER BY block_time DESC NULLS LAST))[1] AS latest_tx_id
+        FROM transactions
+        WHERE subnetwork_id IS NOT NULL
+          AND octet_length(subnetwork_id) BETWEEN 1 AND 4
+        GROUP BY subnetwork_id
+        ORDER BY tx_count DESC
+        LIMIT 20
+        ",
+    )
+    .fetch_all(pool)
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(ApiToccataLaneMetrics {
+            lane_key: row.try_get("lane_key")?,
+            tx_count: row.try_get("tx_count")?,
+            latest_tx_id: row.try_get("latest_tx_id")?,
+        })
+    })
+    .collect::<Result<Vec<_>, Error>>()?;
+
+    Ok(ApiToccataMetrics {
+        tx_v1_count: aggregate.try_get("tx_v1_count")?,
+        block_v2_count: aggregate.try_get("block_v2_count")?,
+        covenant_tx_count: aggregate.try_get("covenant_tx_count")?,
+        covenant_input_count: aggregate.try_get("covenant_input_count")?,
+        covenant_output_count: aggregate.try_get("covenant_output_count")?,
+        covenant_id_count: aggregate.try_get("covenant_id_count")?,
+        user_lane_tx_count: aggregate.try_get("user_lane_tx_count")?,
+        active_user_lanes: aggregate.try_get("active_user_lanes")?,
+        seq_commit_block_count: aggregate.try_get("seq_commit_block_count")?,
+        top_covenants,
+        top_lanes,
+    })
+}
+
+fn row_to_api_block(row: sqlx::postgres::PgRow) -> Result<ApiBlock, Error> {
+    Ok(ApiBlock {
+        hash: row.try_get("hash")?,
+        selected_parent_hash: row.try_get("selected_parent_hash")?,
+        blue_score: row.try_get("blue_score")?,
+        daa_score: row.try_get("daa_score")?,
+        timestamp: row.try_get("timestamp")?,
+        version: row.try_get("version")?,
+        transaction_count: row.try_get("transaction_count")?,
+        is_chain_block: row.try_get("is_chain_block")?,
+    })
+}
+
+fn row_to_api_transaction(row: sqlx::postgres::PgRow) -> Result<ApiTransaction, Error> {
+    Ok(ApiTransaction {
+        transaction_id: row.try_get("transaction_id")?,
+        hash: row.try_get("hash")?,
+        block_time: row.try_get("block_time")?,
+        version: row.try_get("version")?,
+        mass: row.try_get("mass")?,
+        block_hashes: row.try_get("block_hashes")?,
+        accepted_block_hash: row.try_get("accepted_block_hash")?,
+    })
+}
+
+fn parse_hash(value: &str) -> Result<Hash, ()> {
+    use std::str::FromStr;
+    kaspa_hashes::Hash::from_str(value).map(Hash::from).map_err(|_| ())
 }

--- a/indexer/src/web/endpoint/admin.rs
+++ b/indexer/src/web/endpoint/admin.rs
@@ -1,0 +1,285 @@
+use axum::response::Html;
+
+pub const PATH: &str = "/admin";
+
+pub async fn get_admin() -> Html<&'static str> {
+    Html(ADMIN_HTML)
+}
+
+const ADMIN_HTML: &str = r#"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Simply Kaspa Indexer</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f7f8fb;
+      --panel: #ffffff;
+      --text: #17202a;
+      --muted: #657281;
+      --line: #d8dee8;
+      --accent: #146c5f;
+      --warn: #a15c00;
+      --bad: #b42318;
+      --ok: #0e7a45;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #111417;
+        --panel: #191e23;
+        --text: #eef2f5;
+        --muted: #9aa6b2;
+        --line: #2d343c;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 14px/1.45 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 18px 24px;
+      border-bottom: 1px solid var(--line);
+      background: var(--panel);
+    }
+    h1 { margin: 0; font-size: 20px; font-weight: 650; letter-spacing: 0; }
+    main { width: min(1180px, 100%); margin: 0 auto; padding: 20px; }
+    .toolbar, .actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+    button, input {
+      min-height: 36px;
+      border: 1px solid var(--line);
+      background: var(--panel);
+      color: var(--text);
+      border-radius: 6px;
+      padding: 7px 10px;
+      font: inherit;
+    }
+    button { cursor: pointer; }
+    button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+    input { min-width: min(520px, 100%); }
+    .actions input { flex: 1; min-width: min(620px, 100%); }
+    .grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 14px; }
+    .panel {
+      grid-column: span 6;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .panel.wide { grid-column: span 12; }
+    .panel h2 {
+      margin: 0;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--line);
+      font-size: 14px;
+      font-weight: 650;
+    }
+    .content { padding: 14px; }
+    .kv { display: grid; grid-template-columns: minmax(120px, 210px) 1fr; gap: 8px 12px; }
+    .key { color: var(--muted); }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; overflow-wrap: anywhere; }
+    .status { font-weight: 700; }
+    .status.UP, .status.ok { color: var(--ok); }
+    .status.WARN { color: var(--warn); }
+    .status.DOWN, .status.bad { color: var(--bad); }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 9px 10px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; }
+    th { color: var(--muted); font-weight: 600; }
+    tr:last-child td { border-bottom: 0; }
+    .empty { color: var(--muted); }
+    @media (max-width: 780px) {
+      header { align-items: flex-start; flex-direction: column; padding: 16px; }
+      main { padding: 14px; }
+      .panel { grid-column: span 12; }
+      .kv { grid-template-columns: 1fr; }
+      input { width: 100%; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Simply Kaspa Indexer</h1>
+    <div class="toolbar">
+      <input id="search" placeholder="Search block, transaction, or address">
+      <button class="primary" onclick="runSearch()">Search</button>
+      <button onclick="refresh()">Refresh</button>
+    </div>
+  </header>
+  <main>
+    <div class="grid">
+      <section class="panel">
+        <h2>Status</h2>
+        <div id="status" class="content empty">Loading</div>
+      </section>
+      <section class="panel">
+        <h2>Health</h2>
+        <div id="health" class="content empty">Loading</div>
+      </section>
+      <section class="panel wide">
+        <h2>Recent Blocks</h2>
+        <div id="blocks" class="content empty">Loading</div>
+      </section>
+      <section class="panel wide">
+        <h2>Search Results</h2>
+        <div id="results" class="content empty">No query</div>
+      </section>
+      <section class="panel wide">
+        <h2>Address Lookup</h2>
+        <div class="content">
+          <div class="actions">
+            <input id="address" placeholder="kaspa: address">
+            <button class="primary" onclick="queryAddress('transactions')">Transactions</button>
+            <button onclick="queryAddress('balance')">Balance</button>
+            <button onclick="queryAddress('utxos')">UTXOs</button>
+          </div>
+        </div>
+      </section>
+      <section class="panel wide">
+        <h2>Lookup Details</h2>
+        <div id="details" class="content empty">No address query</div>
+      </section>
+    </div>
+  </main>
+  <script>
+    const api = (path) => `${location.pathname.replace(/\/admin\/?$/, "")}${path}`;
+    const text = (value) => value === null || value === undefined || value === "" ? "-" : value;
+    const short = (value) => value && value.length > 18 ? `${value.slice(0, 10)}...${value.slice(-8)}` : text(value);
+    const esc = (value) => String(text(value)).replace(/[&<>"']/g, (ch) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", "\"": "&quot;", "'": "&#39;"
+    })[ch]);
+    async function get(path, options = {}) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), options.timeout || 7000);
+      try {
+        const res = await fetch(api(path), { headers: { accept: "application/json" }, signal: controller.signal });
+        const allowed = options.allowStatus || [];
+        if (!res.ok && !allowed.includes(res.status)) throw new Error(`${res.status} ${res.statusText}`);
+        return res.json();
+      } catch (error) {
+        if (error.name === "AbortError") throw new Error("request timed out");
+        throw error;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+    function healthSyncing(health) {
+      return Boolean(health?.indexer?.details?.some((item) => String(item?.reason || "").includes("behind")));
+    }
+    function kv(rows) {
+      return `<div class="kv">${rows.map(([k, v, cls = ""]) =>
+        `<div class="key">${esc(k)}</div><div class="${cls}">${esc(v)}</div>`).join("")}</div>`;
+    }
+    function renderStatus(status) {
+      const tip = status.chainTip || {};
+      document.getElementById("status").innerHTML = kv([
+        ["tip hash", short(tip.hash), "mono"],
+        ["tip DAA", tip.daaScore],
+        ["checkpoint", short(status.checkpointHash), "mono"],
+        ["checkpoint DAA", status.checkpointDaaScore],
+        ["VCP distance", status.virtualChainTipDistance],
+        ["tx processor", status.transactionProcessorEnabled ? "enabled" : "disabled"],
+      ]);
+    }
+    function renderHealth(health) {
+      const syncing = healthSyncing(health);
+      document.getElementById("health").innerHTML = kv([
+        ["overall", health.status, `status ${health.status}`],
+        ["mode", syncing ? "syncing" : "ready"],
+        ["kaspad", health.kaspad?.status, `status ${health.kaspad?.status}`],
+        ["synced", health.kaspad?.isSynced],
+        ["network", health.kaspad?.networkId],
+        ["indexer", health.indexer?.status, `status ${health.indexer?.status}`],
+        ["uptime", health.indexer?.info?.uptime],
+      ]);
+    }
+    function renderBlocks(blocks) {
+      document.getElementById("blocks").innerHTML = blocks.length ? `<table>
+        <thead><tr><th>Hash</th><th>Blue</th><th>DAA</th><th>Txs</th><th>Chain</th></tr></thead>
+        <tbody>${blocks.map(b => `<tr>
+          <td class="mono" title="${esc(b.hash)}">${esc(short(b.hash))}</td>
+          <td>${esc(b.blueScore)}</td>
+          <td>${esc(b.daaScore)}</td>
+          <td>${esc(b.transactionCount)}</td>
+          <td>${b.isChainBlock ? "yes" : "no"}</td>
+        </tr>`).join("")}</tbody>
+      </table>` : `<span class="empty">No blocks indexed</span>`;
+    }
+    function renderResults(results) {
+      document.getElementById("results").innerHTML = results.length ? `<table>
+        <thead><tr><th>Kind</th><th>Value</th></tr></thead>
+        <tbody>${results.map(r => `<tr><td>${esc(r.kind)}</td><td class="mono">${esc(r.value)}</td></tr>`).join("")}</tbody>
+      </table>` : `<span class="empty">No matches</span>`;
+    }
+    function renderGenericTable(items) {
+      if (!items.length) return `<span class="empty">No rows</span>`;
+      const keys = [...new Set(items.flatMap((item) => Object.keys(item || {})))].slice(0, 8);
+      return `<table><thead><tr>${keys.map((key) => `<th>${esc(key)}</th>`).join("")}</tr></thead>
+        <tbody>${items.map((item) => `<tr>${keys.map((key) => {
+          const value = item?.[key];
+          const display = typeof value === "object" && value !== null ? JSON.stringify(value) : value;
+          return `<td class="mono">${esc(display)}</td>`;
+        }).join("")}</tr>`).join("")}</tbody></table>`;
+    }
+    function renderDetails(title, payload) {
+      const rows = Array.isArray(payload) ? payload : (payload?.transactions || payload?.utxos || null);
+      document.getElementById("details").innerHTML = `<div class="key">${esc(title)}</div><br>` + (
+        Array.isArray(rows) ? renderGenericTable(rows) : kv(Object.entries(payload || {}).map(([key, value]) => [
+          key,
+          typeof value === "object" && value !== null ? JSON.stringify(value) : value,
+          typeof value === "string" && value.length > 24 ? "mono" : "",
+        ]))
+      );
+    }
+    async function refresh() {
+      const [status, health, blocks] = await Promise.allSettled([
+        get("/api/status"),
+        get("/api/health", { allowStatus: [503] }),
+        get("/api/blocks/recent?limit=12"),
+      ]);
+      if (status.status === "fulfilled") renderStatus(status.value);
+      else document.getElementById("status").innerHTML = health.status === "fulfilled" && healthSyncing(health.value)
+        ? `<span class="status WARN">Indexer syncing; status endpoint is busy (${esc(status.reason.message)})</span>`
+        : `<span class="status bad">${esc(status.reason.message)}</span>`;
+      if (health.status === "fulfilled") renderHealth(health.value);
+      else document.getElementById("health").innerHTML = `<span class="status bad">${esc(health.reason.message)}</span>`;
+      if (blocks.status === "fulfilled") renderBlocks(blocks.value);
+      else document.getElementById("blocks").innerHTML = health.status === "fulfilled" && healthSyncing(health.value)
+        ? `<span class="status WARN">Indexer syncing; recent blocks endpoint is busy (${esc(blocks.reason.message)})</span>`
+        : `<span class="status bad">${esc(blocks.reason.message)}</span>`;
+    }
+    async function runSearch() {
+      const q = document.getElementById("search").value.trim();
+      if (!q) return;
+      try { renderResults(await get(`/api/search?q=${encodeURIComponent(q)}`)); }
+      catch (error) { document.getElementById("results").innerHTML = `<span class="status bad">${esc(error.message)}</span>`; }
+    }
+    async function queryAddress(kind) {
+      const address = document.getElementById("address").value.trim();
+      if (!address) return;
+      const path = kind === "transactions"
+        ? `/api/addresses/${encodeURIComponent(address)}/transactions?limit=25`
+        : kind === "balance"
+          ? `/api/addresses/${encodeURIComponent(address)}/balance`
+          : `/api/addresses/${encodeURIComponent(address)}/utxos?limit=25`;
+      try { renderDetails(`${kind}: ${address}`, await get(path, { timeout: 12000 })); }
+      catch (error) { document.getElementById("details").innerHTML = `<span class="status bad">${esc(error.message)}</span>`; }
+    }
+    document.getElementById("search").addEventListener("keydown", (event) => {
+      if (event.key === "Enter") runSearch();
+    });
+    document.getElementById("address").addEventListener("keydown", (event) => {
+      if (event.key === "Enter") queryAddress("transactions");
+    });
+    refresh();
+    setInterval(refresh, 15000);
+  </script>
+</body>
+</html>"#;

--- a/indexer/src/web/endpoint/api.rs
+++ b/indexer/src/web/endpoint/api.rs
@@ -1,0 +1,189 @@
+use crate::web::model::api::{
+    AddressBalance, AddressTransactionSummary, AddressUtxo, BlockSummary, LimitQuery, SearchQuery, SearchResult, Status,
+    TransactionSummary,
+};
+use crate::web::model::metrics::Metrics;
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use kaspa_hashes::Hash as KaspaHash;
+use simply_kaspa_database::client::KaspaDbClient;
+use simply_kaspa_database::models::types::hash::Hash;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub const RECENT_BLOCKS_PATH: &str = "/api/blocks/recent";
+pub const BLOCK_PATH: &str = "/api/blocks/{hash}";
+pub const TRANSACTION_PATH: &str = "/api/transactions/{transaction_id}";
+pub const ADDRESS_TRANSACTIONS_PATH: &str = "/api/addresses/{address}/transactions";
+pub const ADDRESS_BALANCE_PATH: &str = "/api/addresses/{address}/balance";
+pub const ADDRESS_UTXOS_PATH: &str = "/api/addresses/{address}/utxos";
+pub const SEARCH_PATH: &str = "/api/search";
+pub const STATUS_PATH: &str = "/api/status";
+
+#[utoipa::path(
+    method(get),
+    path = RECENT_BLOCKS_PATH,
+    params(LimitQuery),
+    responses((status = StatusCode::OK, body = Vec<BlockSummary>, content_type = "application/json"))
+)]
+pub async fn get_recent_blocks(
+    Query(query): Query<LimitQuery>,
+    Extension(database_client): Extension<KaspaDbClient>,
+) -> impl IntoResponse {
+    match database_client.select_recent_blocks(normalize_limit(query.limit, 50, 250)).await {
+        Ok(blocks) => (StatusCode::OK, Json(blocks.into_iter().map(BlockSummary::from).collect::<Vec<_>>())).into_response(),
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = BLOCK_PATH,
+    params(("hash" = String, Path, description = "Block hash")),
+    responses(
+        (status = StatusCode::OK, body = BlockSummary, content_type = "application/json"),
+        (status = StatusCode::BAD_REQUEST, description = "Invalid hash"),
+        (status = StatusCode::NOT_FOUND, description = "Block not found")
+    )
+)]
+pub async fn get_block(Path(hash): Path<String>, Extension(database_client): Extension<KaspaDbClient>) -> impl IntoResponse {
+    let hash = match parse_hash(&hash) {
+        Ok(hash) => hash,
+        Err(error) => return api_error(StatusCode::BAD_REQUEST, error),
+    };
+    match database_client.select_block(&hash).await {
+        Ok(Some(block)) => (StatusCode::OK, Json(BlockSummary::from(block))).into_response(),
+        Ok(None) => api_error(StatusCode::NOT_FOUND, "block not found"),
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = TRANSACTION_PATH,
+    params(("transaction_id" = String, Path, description = "Transaction id")),
+    responses(
+        (status = StatusCode::OK, body = TransactionSummary, content_type = "application/json"),
+        (status = StatusCode::BAD_REQUEST, description = "Invalid transaction id"),
+        (status = StatusCode::NOT_FOUND, description = "Transaction not found")
+    )
+)]
+pub async fn get_transaction(
+    Path(transaction_id): Path<String>,
+    Extension(database_client): Extension<KaspaDbClient>,
+) -> impl IntoResponse {
+    let transaction_id = match parse_hash(&transaction_id) {
+        Ok(hash) => hash,
+        Err(error) => return api_error(StatusCode::BAD_REQUEST, error),
+    };
+    match database_client.select_transaction(&transaction_id).await {
+        Ok(Some(transaction)) => (StatusCode::OK, Json(TransactionSummary::from(transaction))).into_response(),
+        Ok(None) => api_error(StatusCode::NOT_FOUND, "transaction not found"),
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = ADDRESS_TRANSACTIONS_PATH,
+    params(("address" = String, Path, description = "Kaspa address"), LimitQuery),
+    responses((status = StatusCode::OK, body = Vec<AddressTransactionSummary>, content_type = "application/json"))
+)]
+pub async fn get_address_transactions(
+    Path(address): Path<String>,
+    Query(query): Query<LimitQuery>,
+    Extension(database_client): Extension<KaspaDbClient>,
+) -> impl IntoResponse {
+    match database_client.select_address_transactions(&address, normalize_limit(query.limit, 50, 500)).await {
+        Ok(transactions) => {
+            (StatusCode::OK, Json(transactions.into_iter().map(AddressTransactionSummary::from).collect::<Vec<_>>())).into_response()
+        }
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = ADDRESS_BALANCE_PATH,
+    params(("address" = String, Path, description = "Kaspa address")),
+    responses((status = StatusCode::OK, body = AddressBalance, content_type = "application/json"))
+)]
+pub async fn get_address_balance(
+    Path(address): Path<String>,
+    Extension(database_client): Extension<KaspaDbClient>,
+) -> impl IntoResponse {
+    match database_client.select_address_balance(&address).await {
+        Ok(balance) => (StatusCode::OK, Json(AddressBalance::from(balance))).into_response(),
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = ADDRESS_UTXOS_PATH,
+    params(("address" = String, Path, description = "Kaspa address"), LimitQuery),
+    responses((status = StatusCode::OK, body = Vec<AddressUtxo>, content_type = "application/json"))
+)]
+pub async fn get_address_utxos(
+    Path(address): Path<String>,
+    Query(query): Query<LimitQuery>,
+    Extension(database_client): Extension<KaspaDbClient>,
+) -> impl IntoResponse {
+    match database_client.select_address_utxos(&address, normalize_limit(query.limit, 100, 1000)).await {
+        Ok(utxos) => (StatusCode::OK, Json(utxos.into_iter().map(AddressUtxo::from).collect::<Vec<_>>())).into_response(),
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = SEARCH_PATH,
+    params(SearchQuery),
+    responses((status = StatusCode::OK, body = Vec<SearchResult>, content_type = "application/json"))
+)]
+pub async fn get_search(Query(query): Query<SearchQuery>, Extension(database_client): Extension<KaspaDbClient>) -> impl IntoResponse {
+    match database_client.select_search(&query.q, normalize_limit(query.limit, 10, 50)).await {
+        Ok(results) => (StatusCode::OK, Json(results.into_iter().map(SearchResult::from).collect::<Vec<_>>())).into_response(),
+        Err(error) => api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    }
+}
+
+#[utoipa::path(
+    method(get),
+    path = STATUS_PATH,
+    responses((status = StatusCode::OK, body = Status, content_type = "application/json"))
+)]
+pub async fn get_status(
+    Extension(metrics): Extension<Arc<RwLock<Metrics>>>,
+    Extension(database_client): Extension<KaspaDbClient>,
+) -> impl IntoResponse {
+    let metrics = metrics.read().await.clone();
+    let chain_tip = match database_client.select_recent_blocks(1).await {
+        Ok(mut blocks) => blocks.pop().map(BlockSummary::from),
+        Err(error) => return api_error(StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+    };
+    let status = Status {
+        chain_tip,
+        checkpoint_hash: metrics.checkpoint.block.as_ref().map(|block| block.hash.clone()),
+        checkpoint_daa_score: metrics.checkpoint.block.as_ref().map(|block| block.daa_score),
+        virtual_chain_tip_distance: metrics.components.virtual_chain_processor.tip_distance,
+        transaction_processor_enabled: metrics.components.transaction_processor.enabled,
+        virtual_chain_processor_enabled: metrics.components.virtual_chain_processor.enabled,
+    };
+    (StatusCode::OK, Json(status)).into_response()
+}
+
+fn parse_hash(value: &str) -> Result<Hash, String> {
+    KaspaHash::from_str(value).map(Hash::from).map_err(|_| "invalid kaspa hash".to_string())
+}
+
+fn normalize_limit(limit: Option<i64>, default: i64, max: i64) -> i64 {
+    limit.unwrap_or(default).clamp(1, max)
+}
+
+fn api_error(status: StatusCode, message: impl ToString) -> axum::response::Response {
+    (status, Json(serde_json::json!({ "error": message.to_string() }))).into_response()
+}

--- a/indexer/src/web/endpoint/metrics.rs
+++ b/indexer/src/web/endpoint/metrics.rs
@@ -61,6 +61,10 @@ pub async fn update_metrics(metrics: Arc<RwLock<Metrics>>, system: Arc<RwLock<Sy
         Ok(all_table_details) => metrics.database.tables = Some(all_table_details.into_iter().map(|td| td.into()).collect()),
         Err(e) => warn!("Failed to select all table details: {:?}", e),
     }
+    match database_client.select_toccata_metrics().await {
+        Ok(toccata_metrics) => metrics.toccata.update_from_indexer(toccata_metrics),
+        Err(e) => warn!("Failed to select Toccata metrics: {:?}", e),
+    }
     metrics.clone()
 }
 

--- a/indexer/src/web/endpoint/mod.rs
+++ b/indexer/src/web/endpoint/mod.rs
@@ -1,2 +1,4 @@
+pub mod admin;
+pub mod api;
 pub mod health;
 pub mod metrics;

--- a/indexer/src/web/model/api.rs
+++ b/indexer/src/web/model/api.rs
@@ -1,0 +1,154 @@
+use serde::{Deserialize, Serialize};
+use simply_kaspa_database::models::query::api::{
+    ApiAddressBalance, ApiAddressTransaction, ApiAddressUtxo, ApiBlock, ApiSearchResult, ApiTransaction,
+};
+use utoipa::{IntoParams, ToSchema};
+
+#[derive(Deserialize, IntoParams)]
+pub struct LimitQuery {
+    pub limit: Option<i64>,
+}
+
+#[derive(Deserialize, IntoParams)]
+pub struct SearchQuery {
+    pub q: String,
+    pub limit: Option<i64>,
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockSummary {
+    pub hash: String,
+    pub selected_parent_hash: Option<String>,
+    pub blue_score: Option<i64>,
+    pub daa_score: Option<i64>,
+    pub timestamp: Option<i64>,
+    pub version: Option<i16>,
+    pub transaction_count: i64,
+    pub is_chain_block: bool,
+}
+
+impl From<ApiBlock> for BlockSummary {
+    fn from(block: ApiBlock) -> Self {
+        Self {
+            hash: block.hash.to_string(),
+            selected_parent_hash: block.selected_parent_hash.map(|hash| hash.to_string()),
+            blue_score: block.blue_score,
+            daa_score: block.daa_score,
+            timestamp: block.timestamp,
+            version: block.version,
+            transaction_count: block.transaction_count,
+            is_chain_block: block.is_chain_block,
+        }
+    }
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionSummary {
+    pub transaction_id: String,
+    pub hash: Option<String>,
+    pub block_time: Option<i64>,
+    pub version: Option<i16>,
+    pub mass: Option<i32>,
+    pub block_hashes: Vec<String>,
+    pub accepted_block_hash: Option<String>,
+}
+
+impl From<ApiTransaction> for TransactionSummary {
+    fn from(transaction: ApiTransaction) -> Self {
+        Self {
+            transaction_id: transaction.transaction_id.to_string(),
+            hash: transaction.hash.map(|hash| hash.to_string()),
+            block_time: transaction.block_time,
+            version: transaction.version,
+            mass: transaction.mass,
+            block_hashes: transaction.block_hashes.into_iter().map(|hash| hash.to_string()).collect(),
+            accepted_block_hash: transaction.accepted_block_hash.map(|hash| hash.to_string()),
+        }
+    }
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressTransactionSummary {
+    pub address: String,
+    pub transaction_id: String,
+    pub block_time: i64,
+}
+
+impl From<ApiAddressTransaction> for AddressTransactionSummary {
+    fn from(transaction: ApiAddressTransaction) -> Self {
+        Self {
+            address: transaction.address,
+            transaction_id: transaction.transaction_id.to_string(),
+            block_time: transaction.block_time,
+        }
+    }
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressBalance {
+    pub address: String,
+    pub balance_sompi: i64,
+    pub balance_kas: f64,
+    pub utxo_count: i64,
+}
+
+impl From<ApiAddressBalance> for AddressBalance {
+    fn from(balance: ApiAddressBalance) -> Self {
+        Self {
+            address: balance.address,
+            balance_sompi: balance.balance_sompi,
+            balance_kas: balance.balance_sompi as f64 / 100_000_000.0,
+            utxo_count: balance.utxo_count,
+        }
+    }
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddressUtxo {
+    pub transaction_id: String,
+    pub output_index: i16,
+    pub amount_sompi: i64,
+    pub amount_kas: f64,
+    pub block_time: Option<i64>,
+}
+
+impl From<ApiAddressUtxo> for AddressUtxo {
+    fn from(utxo: ApiAddressUtxo) -> Self {
+        Self {
+            transaction_id: utxo.transaction_id.to_string(),
+            output_index: utxo.output_index,
+            amount_sompi: utxo.amount_sompi,
+            amount_kas: utxo.amount_sompi as f64 / 100_000_000.0,
+            block_time: utxo.block_time,
+        }
+    }
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SearchResult {
+    pub kind: String,
+    pub value: String,
+}
+
+impl From<ApiSearchResult> for SearchResult {
+    fn from(result: ApiSearchResult) -> Self {
+        Self { kind: result.kind, value: result.value }
+    }
+}
+
+#[derive(ToSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Status {
+    pub chain_tip: Option<BlockSummary>,
+    pub checkpoint_hash: Option<String>,
+    pub checkpoint_daa_score: Option<u64>,
+    pub virtual_chain_tip_distance: Option<u64>,
+    pub transaction_processor_enabled: bool,
+    pub virtual_chain_processor_enabled: bool,
+}

--- a/indexer/src/web/model/metrics.rs
+++ b/indexer/src/web/model/metrics.rs
@@ -3,6 +3,8 @@ use crate::settings::Settings;
 use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use simply_kaspa_database::client::KaspaDbClient;
+use simply_kaspa_database::models::query::api::{ApiToccataCovenantMetrics, ApiToccataLaneMetrics, ApiToccataMetrics};
 use simply_kaspa_database::models::query::database_details::DatabaseDetails;
 use simply_kaspa_database::models::query::table_details::TableDetails;
 use std::collections::HashMap;
@@ -14,6 +16,7 @@ use utoipa::ToSchema;
 pub struct Metrics {
     pub name: String,
     pub version: String,
+    pub schema_version: u8,
     pub commit_id: String,
     pub settings: Option<Settings>,
     pub process: MetricsProcess,
@@ -21,6 +24,7 @@ pub struct Metrics {
     pub checkpoint: MetricsCheckpoint,
     pub components: MetricsComponent,
     pub database: MetricsDb,
+    pub toccata: MetricsToccata,
 }
 
 impl Metrics {
@@ -28,6 +32,7 @@ impl Metrics {
         Self {
             name,
             version,
+            schema_version: KaspaDbClient::SCHEMA_VERSION,
             commit_id,
             settings: None,
             process: MetricsProcess::new(),
@@ -35,8 +40,194 @@ impl Metrics {
             checkpoint: MetricsCheckpoint::new(),
             components: MetricsComponent::new(),
             database: MetricsDb::new(),
+            toccata: MetricsToccata::new(),
         }
     }
+}
+
+#[derive(ToSchema, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsToccata {
+    pub tx_version_1: bool,
+    pub storage_mass: bool,
+    pub compute_budget: bool,
+    pub covenant_binding: bool,
+    pub utxo_covenant_id: bool,
+    pub subnetwork_id: bool,
+    pub gas: bool,
+    pub get_block_reward_info: bool,
+    pub get_seq_commit_lane_proof: bool,
+    pub minimum_relay_fee_sompi_per_gram: u64,
+    pub tx_v1_count: u64,
+    pub block_v2_count: u64,
+    pub covenant_tx_count: u64,
+    pub covenant_input_count: u64,
+    pub covenant_output_count: u64,
+    pub covenant_utxo_count: u64,
+    pub covenant_id_count: u64,
+    pub active_user_lanes: u64,
+    pub user_lane_tx_count: u64,
+    pub gas_total: u64,
+    pub seq_commit_block_count: u64,
+    pub storage_mass_max: u64,
+    pub storage_mass_avg: u64,
+    pub compute_mass_max: u64,
+    pub transient_mass_max: u64,
+    pub low_fee_rejections: u64,
+    pub zk_precompile_tx_count: u64,
+    pub groth16_tx_count: u64,
+    pub risc0_tx_count: u64,
+    pub zk_proof_failures: u64,
+    pub bridge_lockbox_count: u64,
+    pub bridge_unlock_count: u64,
+    pub token_candidate_count: u64,
+    pub nft_candidate_count: u64,
+    pub lane_proof_failures: u64,
+    pub top_covenants: Vec<MetricsToccataCovenant>,
+    pub top_lanes: Vec<MetricsToccataLane>,
+    pub top_zk_proofs: Vec<MetricsToccataZkProof>,
+    pub bridge_lockboxes: Vec<MetricsToccataBridgeLockbox>,
+}
+
+impl Default for MetricsToccata {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MetricsToccata {
+    pub fn new() -> Self {
+        Self {
+            tx_version_1: true,
+            storage_mass: false,
+            compute_budget: true,
+            covenant_binding: true,
+            utxo_covenant_id: true,
+            subnetwork_id: true,
+            gas: false,
+            get_block_reward_info: false,
+            get_seq_commit_lane_proof: false,
+            minimum_relay_fee_sompi_per_gram: 100,
+            tx_v1_count: 0,
+            block_v2_count: 0,
+            covenant_tx_count: 0,
+            covenant_input_count: 0,
+            covenant_output_count: 0,
+            covenant_utxo_count: 0,
+            covenant_id_count: 0,
+            active_user_lanes: 0,
+            user_lane_tx_count: 0,
+            gas_total: 0,
+            seq_commit_block_count: 0,
+            storage_mass_max: 0,
+            storage_mass_avg: 0,
+            compute_mass_max: 0,
+            transient_mass_max: 0,
+            low_fee_rejections: 0,
+            zk_precompile_tx_count: 0,
+            groth16_tx_count: 0,
+            risc0_tx_count: 0,
+            zk_proof_failures: 0,
+            bridge_lockbox_count: 0,
+            bridge_unlock_count: 0,
+            token_candidate_count: 0,
+            nft_candidate_count: 0,
+            lane_proof_failures: 0,
+            top_covenants: Vec::new(),
+            top_lanes: Vec::new(),
+            top_zk_proofs: Vec::new(),
+            bridge_lockboxes: Vec::new(),
+        }
+    }
+
+    pub fn update_from_indexer(&mut self, metrics: ApiToccataMetrics) {
+        self.tx_v1_count = metrics.tx_v1_count.max(0) as u64;
+        self.block_v2_count = metrics.block_v2_count.max(0) as u64;
+        self.covenant_tx_count = metrics.covenant_tx_count.max(0) as u64;
+        self.covenant_input_count = metrics.covenant_input_count.max(0) as u64;
+        self.covenant_output_count = metrics.covenant_output_count.max(0) as u64;
+        self.covenant_utxo_count = metrics.covenant_output_count.max(0) as u64;
+        self.covenant_id_count = metrics.covenant_id_count.max(0) as u64;
+        self.user_lane_tx_count = metrics.user_lane_tx_count.max(0) as u64;
+        self.active_user_lanes = metrics.active_user_lanes.max(0) as u64;
+        self.seq_commit_block_count = metrics.seq_commit_block_count.max(0) as u64;
+        self.top_covenants = metrics.top_covenants.into_iter().map(MetricsToccataCovenant::from).collect();
+        self.top_lanes = metrics.top_lanes.into_iter().map(MetricsToccataLane::from).collect();
+    }
+}
+
+#[derive(ToSchema, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsToccataCovenant {
+    pub covenant_id: String,
+    pub tx_count: u64,
+    pub utxo_count: u64,
+    pub input_count: u64,
+    pub output_count: u64,
+    pub token_like: bool,
+    pub nft_like: bool,
+    pub latest_tx_id: Option<String>,
+}
+
+impl From<ApiToccataCovenantMetrics> for MetricsToccataCovenant {
+    fn from(covenant: ApiToccataCovenantMetrics) -> Self {
+        Self {
+            covenant_id: covenant.covenant_id,
+            tx_count: covenant.tx_count.max(0) as u64,
+            utxo_count: covenant.output_count.max(0) as u64,
+            input_count: covenant.input_count.max(0) as u64,
+            output_count: covenant.output_count.max(0) as u64,
+            token_like: false,
+            nft_like: covenant.output_count == 1,
+            latest_tx_id: covenant.latest_tx_id.map(|tx_id| tx_id.to_string()),
+        }
+    }
+}
+
+#[derive(ToSchema, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsToccataLane {
+    pub lane_key: String,
+    pub tx_count: u64,
+    pub gas_total: u64,
+    pub seq_commit_block_count: u64,
+    pub lane_proof_ok: bool,
+    pub latest_block_hash: Option<String>,
+    pub latest_tx_id: Option<String>,
+}
+
+impl From<ApiToccataLaneMetrics> for MetricsToccataLane {
+    fn from(lane: ApiToccataLaneMetrics) -> Self {
+        Self {
+            lane_key: lane.lane_key,
+            tx_count: lane.tx_count.max(0) as u64,
+            gas_total: 0,
+            seq_commit_block_count: 0,
+            lane_proof_ok: false,
+            latest_block_hash: None,
+            latest_tx_id: lane.latest_tx_id.map(|tx_id| tx_id.to_string()),
+        }
+    }
+}
+
+#[derive(ToSchema, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsToccataZkProof {
+    pub proof_type: String,
+    pub tx_count: u64,
+    pub failure_count: u64,
+    pub latest_tx_id: Option<String>,
+}
+
+#[derive(ToSchema, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetricsToccataBridgeLockbox {
+    pub label: String,
+    pub covenant_id: Option<String>,
+    pub locked_amount_sompi: u64,
+    pub unlock_tx_count: u64,
+    pub proof_type: String,
+    pub latest_tx_id: Option<String>,
 }
 
 #[derive(ToSchema, Clone, Serialize, Deserialize)]

--- a/indexer/src/web/model/metrics.rs
+++ b/indexer/src/web/model/metrics.rs
@@ -48,6 +48,7 @@ impl Metrics {
 #[derive(ToSchema, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetricsToccata {
+    pub rollup_updated_at: Option<i64>,
     pub tx_version_1: bool,
     pub storage_mass: bool,
     pub compute_budget: bool,
@@ -107,6 +108,7 @@ impl MetricsToccata {
             gas: false,
             get_block_reward_info: false,
             get_seq_commit_lane_proof: false,
+            rollup_updated_at: None,
             minimum_relay_fee_sompi_per_gram: 100,
             tx_v1_count: 0,
             block_v2_count: 0,
@@ -141,6 +143,7 @@ impl MetricsToccata {
     }
 
     pub fn update_from_indexer(&mut self, metrics: ApiToccataMetrics) {
+        self.rollup_updated_at = metrics.rollup_updated_at;
         self.tx_v1_count = metrics.tx_v1_count.max(0) as u64;
         self.block_v2_count = metrics.block_v2_count.max(0) as u64;
         self.covenant_tx_count = metrics.covenant_tx_count.max(0) as u64;

--- a/indexer/src/web/model/mod.rs
+++ b/indexer/src/web/model/mod.rs
@@ -1,2 +1,3 @@
+pub mod api;
 pub mod health;
 pub mod metrics;

--- a/indexer/src/web/web_server.rs
+++ b/indexer/src/web/web_server.rs
@@ -1,6 +1,6 @@
 use crate::settings::Settings;
 use crate::web::endpoint;
-use crate::web::endpoint::{health, metrics};
+use crate::web::endpoint::{admin, api, health, metrics};
 use crate::web::model::metrics::Metrics;
 use axum::body::{Body, to_bytes};
 use axum::http::{HeaderValue, Request, header};
@@ -35,6 +35,14 @@ pub const INFO_TAG: &str = "info";
     paths(
         endpoint::health::get_health,
         endpoint::metrics::get_metrics,
+        endpoint::api::get_recent_blocks,
+        endpoint::api::get_block,
+        endpoint::api::get_transaction,
+        endpoint::api::get_address_transactions,
+        endpoint::api::get_address_balance,
+        endpoint::api::get_address_utxos,
+        endpoint::api::get_search,
+        endpoint::api::get_status,
     ),
     tags(
         (name = INFO_TAG, description = "Info API endpoints"),
@@ -69,6 +77,15 @@ impl WebServer {
         let (api_router, api) = OpenApiRouter::with_openapi(set_server_path(base_path))
             .route(&format!("{}{}", base_path, health::PATH), get(health::get_health))
             .route(&format!("{}{}", base_path, metrics::PATH), get(metrics::get_metrics))
+            .route(&format!("{}{}", base_path, api::RECENT_BLOCKS_PATH), get(api::get_recent_blocks))
+            .route(&format!("{}{}", base_path, api::BLOCK_PATH), get(api::get_block))
+            .route(&format!("{}{}", base_path, api::TRANSACTION_PATH), get(api::get_transaction))
+            .route(&format!("{}{}", base_path, api::ADDRESS_TRANSACTIONS_PATH), get(api::get_address_transactions))
+            .route(&format!("{}{}", base_path, api::ADDRESS_BALANCE_PATH), get(api::get_address_balance))
+            .route(&format!("{}{}", base_path, api::ADDRESS_UTXOS_PATH), get(api::get_address_utxos))
+            .route(&format!("{}{}", base_path, api::SEARCH_PATH), get(api::get_search))
+            .route(&format!("{}{}", base_path, api::STATUS_PATH), get(api::get_status))
+            .route(&format!("{}{}", base_path, admin::PATH), get(admin::get_admin))
             .split_for_parts();
         let swagger_config = Config::default().use_base_layout().try_it_out_enabled(true).display_request_duration(true);
         let swagger =


### PR DESCRIPTION
Adds a lightweight REST explorer/admin surface and extends /api/metrics with a Toccata monitoring section.\n\nSummary:\n- Add /api/status, recent block, block, transaction, address, UTXO, and search endpoints\n- Add /admin operator dashboard\n- Expose schemaVersion and metrics.toccata counters for tx v1, block v2, covenant activity, user lanes, and seqcommit blocks\n- Mark unsupported post-Toccata fields explicitly until the database stores them\n- Document API endpoints and Toccata metrics behavior\n\nValidation:\n- cargo fmt\n- cargo check\n- cargo test